### PR TITLE
added permissions to job

### DIFF
--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -13,6 +13,8 @@ jobs:
   permissions:
     actions: read
     contents: read
+    checks: write
+    pull-requests: write
   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
   with:
     artifact_name: 'dan-plugin-skatteetaten' # Can be omitted, defaults to 'artifact'


### PR DESCRIPTION
### Description
<!--- What and why -->
post-deploy-tests is failing. This might be due to insufficient permissions
### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enable expanded access scopes for checks and pull-request interactions during automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->