### PR TITLE
Feat/create dtos

### DIFF
--- a/src/Dan.Plugin.Skatteetaten/ArrearsV2.cs
+++ b/src/Dan.Plugin.Skatteetaten/ArrearsV2.cs
@@ -2,12 +2,15 @@ using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Dan.Common.Util;
 using Dan.Plugin.Skatteetaten.Config;
+using Dan.Plugin.Skatteetaten.Models;
+using Dan.Plugin.Skatteetaten.Models.Arrears;
+using Dan.Plugin.Skatteetaten.Models.Dtos;
 using Dan.Plugin.Skatteetaten.Utilities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
+using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -37,73 +40,18 @@ namespace Dan.Plugin.Skatteetaten
         public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req, FunctionContext context)
         {
             var evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
-            return await EvidenceSourceResponse.CreateResponse(req, ()=> GetArrearsFromSkeAsync(evidenceHarvesterRequest));
+            return await EvidenceSourceResponse.CreateResponse(req, () => GetArrearsFromSkeAsync(evidenceHarvesterRequest));
         }
 
         private async Task<List<EvidenceValue>> GetArrearsFromSkeAsync(EvidenceHarvesterRequest evidenceHarvesterRequest)
         {
             var url = $"{_settings.RestanserEndpoint}/v2/ebevis/{evidenceHarvesterRequest.OrganizationNumber}";
-            dynamic result = await Helpers.HarvestFromSke(evidenceHarvesterRequest, _logger, _client, HttpMethod.Get, url, _settings);
+            var result = await Helpers.HarvestFromSke<ArrearsModel>(evidenceHarvesterRequest, _logger, _client, HttpMethod.Get, url, _settings);
 
-            string orgNo = "";
-            DateTime? delivered = null;
-            string AGA = "";
-            string withholdingDueAndUnpaid = "";
-            string preemptiveTaxUnpaid = "";
-            string remainingTaxes = "";
-            string remainingAdditionalCharges = "";
-            string VAT = "";
-
-            if (result["levert"] != null)
-            {
-                delivered = result["levert"];
-            }
-
-            if (result["forespurteOrganisasjon"] != null)
-            {
-                orgNo = result["forespurteOrganisasjon"];
-            }
-
-            if (result["restanser"]["arbeidsgiveravgift"]["forfaltOgUbetalt"] != null)
-            {
-                AGA = result["restanser"]["arbeidsgiveravgift"]["forfaltOgUbetalt"] + " NOK";
-            }
-
-            if (result["restanser"]["forskuddstrekk"]["forfaltOgUbetalt"] != null)
-            {
-                withholdingDueAndUnpaid = result["restanser"]["forskuddstrekk"]["forfaltOgUbetalt"] + " NOK";
-            }
-
-            if (result["restanser"]["forskuddsskatt"]["forfaltOgUbetalt"] != null)
-            {
-                preemptiveTaxUnpaid = result["restanser"]["forskuddsskatt"]["forfaltOgUbetalt"] + " NOK";
-            }
-
-            if (result["restanser"]["restskatt"]["forfaltOgUbetalt"] != null)
-            {
-                remainingTaxes = result["restanser"]["restskatt"]["forfaltOgUbetalt"] + " NOK";
-            }
-
-            if (result["restanser"]["gebyr"]["forfaltOgUbetalt"] != null)
-            {
-                remainingAdditionalCharges = result["restanser"]["gebyr"]["forfaltOgUbetalt"] + " NOK";
-            }
-
-            if (result["restanser"]["merverdiavgift"]["forfaltOgUbetalt"] != null)
-            {
-                VAT = result["restanser"]["merverdiavgift"]["forfaltOgUbetalt"] + " NOK";
-            }
+            var dto = new RestanserV2Dto(result);
 
             var ecb = new EvidenceBuilder(_evidenceSourceMetadata, "RestanserV2");
-
-            ecb.AddEvidenceValue($"levert", delivered);
-            ecb.AddEvidenceValue($"forespurteOrganisasjon", orgNo);
-            ecb.AddEvidenceValue($"arbeidsgiveravgiftForfaltOgUbetalt", AGA);
-            ecb.AddEvidenceValue($"forskuddstrekkForfaltOgUbetalt", withholdingDueAndUnpaid);
-            ecb.AddEvidenceValue($"forskuddsskattForfaltOgUbetalt", preemptiveTaxUnpaid);
-            ecb.AddEvidenceValue($"restskattForfaltOgUbetalt", remainingTaxes);
-            ecb.AddEvidenceValue($"gebyrForfaltOgUbetalt", remainingAdditionalCharges);
-            ecb.AddEvidenceValue($"merverdiavgiftForfaltOgUbetalt", VAT);
+            ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(dto), Constants.Source, false);
             return ecb.GetEvidenceValues();
         }
     }

--- a/src/Dan.Plugin.Skatteetaten/Freg.cs
+++ b/src/Dan.Plugin.Skatteetaten/Freg.cs
@@ -189,12 +189,17 @@ namespace Dan.Plugin.Skatteetaten
             return await EvidenceSourceResponse.CreateResponse(req, () => GetFregSisteSekvensnummer(evidenceHarvesterRequest, url));
         }
 
+        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore
+        };
+
         private async Task<List<EvidenceValue>> GetFregPerson(EvidenceHarvesterRequest req, string url)
         {
             var result = await Helpers.HarvestFromSke<FregPersonDto>(req, _logger, _client, HttpMethod.Get, url);
 
             var ecb = new EvidenceBuilder(_metadata, "FregPerson");
-            ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(result), "Skatteetaten", false);
+            ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(result, _jsonSettings), "Skatteetaten", false);
 
             return ecb.GetEvidenceValues();
         }
@@ -204,7 +209,7 @@ namespace Dan.Plugin.Skatteetaten
             var result = await Helpers.HarvestFromSke<FregPersonDto>(req, _logger, _client, HttpMethod.Get, url);
 
             var ecb = new EvidenceBuilder(_metadata, "FregPersonRelasjonUtvidet");
-            ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(result), "Skatteetaten", false);
+            ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(result, _jsonSettings), "Skatteetaten", false);
 
             return ecb.GetEvidenceValues();
         }

--- a/src/Dan.Plugin.Skatteetaten/Freg.cs
+++ b/src/Dan.Plugin.Skatteetaten/Freg.cs
@@ -5,6 +5,7 @@ using Dan.Common.Models;
 using Dan.Common.Util;
 using Dan.Plugin.Skatteetaten.Config;
 using Dan.Plugin.Skatteetaten.Models;
+using Dan.Plugin.Skatteetaten.Models.Dtos;
 using Dan.Plugin.Skatteetaten.Utilities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -190,9 +191,7 @@ namespace Dan.Plugin.Skatteetaten
 
         private async Task<List<EvidenceValue>> GetFregPerson(EvidenceHarvesterRequest req, string url)
         {
-            //req.MPToken = req.MPToken ?? GetToken(req.ServiceContext);
-
-            var result = await Helpers.HarvestFromSke(req, _logger, _client, HttpMethod.Get, url);
+            var result = await Helpers.HarvestFromSke<FregPersonDto>(req, _logger, _client, HttpMethod.Get, url);
 
             var ecb = new EvidenceBuilder(_metadata, "FregPerson");
             ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(result), "Skatteetaten", false);
@@ -202,9 +201,7 @@ namespace Dan.Plugin.Skatteetaten
 
         private async Task<List<EvidenceValue>> GetFregPersonRelasjonUtvidet(EvidenceHarvesterRequest req, string url)
         {
-            //req.MPToken = req.MPToken ?? GetToken(req.ServiceContext);
-
-            var result = await Helpers.HarvestFromSke(req, _logger, _client, HttpMethod.Get, url);
+            var result = await Helpers.HarvestFromSke<FregPersonDto>(req, _logger, _client, HttpMethod.Get, url);
 
             var ecb = new EvidenceBuilder(_metadata, "FregPersonRelasjonUtvidet");
             ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(result), "Skatteetaten", false);

--- a/src/Dan.Plugin.Skatteetaten/Metadata.cs
+++ b/src/Dan.Plugin.Skatteetaten/Metadata.cs
@@ -319,7 +319,7 @@ public class Metadata : IEvidenceSourceMetadata
                             EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
                             Source = SourceTaxDepartment,
-                            JsonSchemaDefintion =  ""
+                            JsonSchemaDefintion = JsonSchema.FromType<FregPersonDto>().ToJson(Newtonsoft.Json.Formatting.Indented)
                         }
                     },
                     Parameters = new List<EvidenceParameter>()
@@ -379,7 +379,7 @@ public class Metadata : IEvidenceSourceMetadata
                             EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
                             Source = SourceTaxDepartment,
-                            JsonSchemaDefintion =  ""
+                            JsonSchemaDefintion = JsonSchema.FromType<FregPersonDto>().ToJson(Newtonsoft.Json.Formatting.Indented)
                         }
                     },
                     Parameters = new List<EvidenceParameter>()
@@ -399,7 +399,7 @@ public class Metadata : IEvidenceSourceMetadata
                     MaxValidDays =  90,
                     RequiredScopes = "folkeregister:deling/offentligutenhjemmel",
                     BelongsToServiceContexts = new List<string>
-                    {                        
+                    {
                         ServiceContextAltinnStudioApps
                     },
                     AuthorizationRequirements = new List<Requirement>()
@@ -411,8 +411,8 @@ public class Metadata : IEvidenceSourceMetadata
                                 new KeyValuePair<AccreditationPartyTypes, PartyTypeConstraint>(
                                     AccreditationPartyTypes.Subject, PartyTypeConstraint.PrivatePerson)
                             }
-                        },                      
-                        new ProvideOwnTokenRequirement(),                       
+                        },
+                        new ProvideOwnTokenRequirement(),
                         new MaskinportenScopeRequirement()
                         {
                             RequiredScopes = new List<string>() { "dan:altinnstudioapps" },
@@ -426,7 +426,7 @@ public class Metadata : IEvidenceSourceMetadata
                             EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
                             Source = SourceTaxDepartment,
-                            JsonSchemaDefintion =  ""
+                            JsonSchemaDefintion = JsonSchema.FromType<FregPersonDto>().ToJson(Newtonsoft.Json.Formatting.Indented)
                         }
                     },
                     Parameters = new List<EvidenceParameter>()

--- a/src/Dan.Plugin.Skatteetaten/Metadata.cs
+++ b/src/Dan.Plugin.Skatteetaten/Metadata.cs
@@ -205,22 +205,10 @@ public class Metadata : IEvidenceSourceMetadata
                     {
                         new EvidenceValue()
                         {
-                            EvidenceValueName = "levert",
-                            ValueType = EvidenceValueType.DateTime,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "forespurteOrganisasjon",
-                            ValueType = EvidenceValueType.String,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "mvaAlminneligNaering",
+                            EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
                             Source = SourceTaxDepartment,
-                            JsonSchemaDefintion = JsonSchema.FromType<MvaAlminneligNaering>().ToJson(Newtonsoft.Json.Formatting.Indented)
+                            JsonSchemaDefintion = JsonSchema.FromType<MvaMeldingsOpplysningDto>().ToJson(Newtonsoft.Json.Formatting.Indented)
                         }
                     }
                 },

--- a/src/Dan.Plugin.Skatteetaten/Metadata.cs
+++ b/src/Dan.Plugin.Skatteetaten/Metadata.cs
@@ -1,9 +1,8 @@
 using Dan.Common.Enums;
 using Dan.Common.Interfaces;
 using Dan.Common.Models;
-using Dan.Plugin.Skatteetaten;
 using Dan.Plugin.Skatteetaten.Models;
-using Dan.Plugin.Skatteetaten.Models.Arbeidsgiveravgift;
+using Dan.Plugin.Skatteetaten.Models.Dtos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using System.Collections.Generic;
@@ -144,55 +143,10 @@ public class Metadata : IEvidenceSourceMetadata
                     {
                         new EvidenceValue()
                         {
-                            EvidenceValueName = "levert",
-                            ValueType = EvidenceValueType.DateTime,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "forespurteOrganisasjon",
-                            ValueType = EvidenceValueType.String,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "arbeidsgiveravgiftForfaltOgUbetalt",
-                            ValueType = EvidenceValueType.Amount,
-                            Source = SourceTaxDepartment
-                        },
-
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "forskuddstrekkForfaltOgUbetalt",
-                            ValueType = EvidenceValueType.Amount,
-                            Source = SourceTaxDepartment
-                        },
-
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "forskuddsskattForfaltOgUbetalt",
-                            ValueType = EvidenceValueType.Amount,
-                            Source = SourceTaxDepartment
-                        },
-
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "restskattForfaltOgUbetalt",
-                            ValueType = EvidenceValueType.Amount,
-                            Source = SourceTaxDepartment
-                        },
-
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "gebyrForfaltOgUbetalt",
-                            ValueType = EvidenceValueType.Amount,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "merverdiavgiftForfaltOgUbetalt",
-                            ValueType = EvidenceValueType.Amount,
-                            Source = SourceTaxDepartment
+                            EvidenceValueName = "default",
+                            ValueType = EvidenceValueType.JsonSchema,
+                            Source = SourceTaxDepartment,
+                            JsonSchemaDefintion = JsonSchema.FromType<RestanserV2Dto>().ToJson(Newtonsoft.Json.Formatting.Indented)
                         }
                     }
                 },      
@@ -234,22 +188,10 @@ public class Metadata : IEvidenceSourceMetadata
                     {
                         new EvidenceValue()
                         {
-                            EvidenceValueName = "levert",
-                            ValueType = EvidenceValueType.DateTime,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "forespurteOrganisasjon",
-                            ValueType = EvidenceValueType.String,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "arbeidsgiveravgifter",
+                            EvidenceValueName = "default",
                             ValueType = EvidenceValueType.JsonSchema,
-                            JsonSchemaDefintion = JsonSchema.FromType<PayrollTaxModel>().ToJson(Newtonsoft.Json.Formatting.Indented),
-                            Source = SourceTaxDepartment
+                            Source = SourceTaxDepartment,
+                            JsonSchemaDefintion = JsonSchema.FromType<ArbeidsgiveravgiftDto>().ToJson(Newtonsoft.Json.Formatting.Indented)
                         }
                     }
                 },

--- a/src/Dan.Plugin.Skatteetaten/Metadata.cs
+++ b/src/Dan.Plugin.Skatteetaten/Metadata.cs
@@ -3,6 +3,7 @@ using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Dan.Plugin.Skatteetaten.Models;
 using Dan.Plugin.Skatteetaten.Models.Dtos;
+using Dan.Plugin.Skatteetaten.Models.OppdragUtenlandskeVirksomheter;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using System.Collections.Generic;
@@ -75,40 +76,11 @@ public class Metadata : IEvidenceSourceMetadata
                     {
                         new EvidenceValue()
                         {
-                            EvidenceValueName = "organisasjonsnavn",
-                            ValueType = EvidenceValueType.String,
-                            Source = SourceTaxDepartment
-                        },
-                         new EvidenceValue()
-                        {
-                            EvidenceValueName = "organisasjonsnummer",
-                            ValueType = EvidenceValueType.String,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "antallAktiveOppdragSomArbeidsgiver",
-                            ValueType = EvidenceValueType.Number,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "antallAktiveArbeidstakere",
-                            ValueType = EvidenceValueType.Number,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "antallRegistrerteOppdragSomOppdragsgiver",
-                            ValueType = EvidenceValueType.Number,
-                            Source = SourceTaxDepartment
-                        },
-                        new EvidenceValue()
-                        {
-                            EvidenceValueName = "levert",
-                            ValueType = EvidenceValueType.DateTime,
-                            Source = SourceTaxDepartment
-                        },
+                            EvidenceValueName = "default",
+                            ValueType = EvidenceValueType.JsonSchema,
+                            Source = SourceTaxDepartment,
+                            JsonSchemaDefintion = JsonSchema.FromType<OppdragUtenlandskeVirksomheterDto>().ToJson(Newtonsoft.Json.Formatting.Indented)
+                        }
                     }
                 },
                 new EvidenceCode()

--- a/src/Dan.Plugin.Skatteetaten/Models/ArrearsModel.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/ArrearsModel.cs
@@ -1,55 +1,28 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Dan.Plugin.Skatteetaten.Models.Arrears
 {
-    class ArrearsModel
+    public class ArrearsModel
     {
         public DateTime levert { get; set; }
-        public int forespurteOrganisasjon { get; set; }
+        public string forespurteOrganisasjon { get; set; }
         public Restanser restanser { get; set; }
     }
 
-    public class Arbeidsgiveravgift
+    public class RestanserKategori
     {
-        public int forfaltOgUbetalt { get; set; }
-    }
-
-    public class Forskuddstrekk
-    {
-        public int forfaltOgUbetalt { get; set; }
-    }
-
-    public class Forskuddsskatt
-    {
-        public int forfaltOgUbetalt { get; set; }
-    }
-
-    public class Restskatt
-    {
-        public int forfaltOgUbetalt { get; set; }
-    }
-
-    public class Gebyr
-    {
-        public int forfaltOgUbetalt { get; set; }
-    }
-
-    public class Merverdiavgift
-    {
-        public int forfaltOgUbetalt { get; set; }
+        public decimal forfaltOgUbetalt { get; set; }
+        public decimal forfaltOgUbetaltRenter { get; set; }
+        public decimal forfaltOgUbetaltKrav { get; set; }
     }
 
     public class Restanser
     {
-        public Arbeidsgiveravgift arbeidsgiveravgift { get; set; }
-        public Forskuddstrekk forskuddstrekk { get; set; }
-        public Forskuddsskatt forskuddsskatt { get; set; }
-        public Restskatt restskatt { get; set; }
-        public Gebyr gebyr { get; set; }
-        public Merverdiavgift merverdiavgift { get; set; }
+        public RestanserKategori arbeidsgiveravgift { get; set; }
+        public RestanserKategori forskuddstrekk { get; set; }
+        public RestanserKategori forskuddsskatt { get; set; }
+        public RestanserKategori restskatt { get; set; }
+        public RestanserKategori gebyr { get; set; }
+        public RestanserKategori merverdiavgift { get; set; }
     }
 }
-
-  

--- a/src/Dan.Plugin.Skatteetaten/Models/Dtos/ArbeidsgiveravgiftDto.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/Dtos/ArbeidsgiveravgiftDto.cs
@@ -1,0 +1,49 @@
+using Dan.Plugin.Skatteetaten.Models.Arbeidsgiveravgift;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Dan.Plugin.Skatteetaten.Models.Dtos;
+
+[Serializable]
+public class ArbeidsgiveravgiftDto
+{
+    public ArbeidsgiveravgiftDto(PayrollTaxModel model)
+    {
+        Levert = model.levert;
+        ForespurteOrganisasjon = model.forespurteOrganisasjon;
+        Arbeidsgiveravgifter = model.arbeidsgiveravgifter?
+            .Select(w => new ArbeidsgiveravgiftEntryDto(w.arbeidsgiveravgift))
+            .ToList() ?? new List<ArbeidsgiveravgiftEntryDto>();
+    }
+
+    [JsonProperty("levert")]
+    public DateTime Levert { get; set; }
+
+    [JsonProperty("forespurteOrganisasjon")]
+    public string ForespurteOrganisasjon { get; set; }
+
+    [JsonProperty("arbeidsgiveravgifter")]
+    public List<ArbeidsgiveravgiftEntryDto> Arbeidsgiveravgifter { get; set; }
+}
+
+[Serializable]
+public class ArbeidsgiveravgiftEntryDto
+{
+    public ArbeidsgiveravgiftEntryDto(ArbeidsgiveravgiftEntry entry)
+    {
+        Termin = entry.termin;
+        Aar = entry.aar;
+        SumavgiftsgrunnlagBeloep = entry.sumavgiftsgrunnlagBeloep;
+    }
+
+    [JsonProperty("termin")]
+    public string Termin { get; set; }
+
+    [JsonProperty("aar")]
+    public string Aar { get; set; }
+
+    [JsonProperty("sumavgiftsgrunnlagBeloep")]
+    public long SumavgiftsgrunnlagBeloep { get; set; }
+}

--- a/src/Dan.Plugin.Skatteetaten/Models/Dtos/FregPersonDto.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/Dtos/FregPersonDto.cs
@@ -1,0 +1,1644 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Dan.Plugin.Skatteetaten.Models.Dtos;
+
+// ── Root ─────────────────────────────────────────────────────────────────────
+
+[Serializable]
+public class FregPersonDto
+{
+    [JsonProperty("adressebeskyttelse")]
+    public List<AdressebeskyttelseDto> Adressebeskyttelse { get; set; }
+
+    [JsonProperty("bibehold")]
+    public List<BibeholdDto> Bibehold { get; set; }
+
+    [JsonProperty("bostedsadresse")]
+    public List<BostedsadresseDto> Bostedsadresse { get; set; }
+
+    [JsonProperty("brukAvSamiskSpraak")]
+    public List<BrukAvSamiskSpraakDto> BrukAvSamiskSpraak { get; set; }
+
+    [JsonProperty("deltBosted")]
+    public List<DeltBostedDto> DeltBosted { get; set; }
+
+    [JsonProperty("doedsfall")]
+    public DoedsfallDto Doedsfall { get; set; }
+
+    [JsonProperty("falskIdentitet")]
+    public FalskIdentitetDto FalskIdentitet { get; set; }
+
+    [JsonProperty("familierelasjon")]
+    public List<FamilierelasjonsDto> Familierelasjon { get; set; }
+
+    [JsonProperty("foedsel")]
+    public List<FoedselDto> Foedsel { get; set; }
+
+    [JsonProperty("foedselINorge")]
+    public List<FoedselINorgeDto> FoedselINorge { get; set; }
+
+    [JsonProperty("foreldreansvar")]
+    public List<ForeldreansvarDto> Foreldreansvar { get; set; }
+
+    [JsonProperty("forholdTilSametingetsValgmanntall")]
+    public List<ForholdTilSametingetsValgmanntallDto> ForholdTilSametingetsValgmanntall { get; set; }
+
+    [JsonProperty("fratattRettsligHandleevne")]
+    public List<FratattRettsligHandleevneDto> FratattRettsligHandleevne { get; set; }
+
+    [JsonProperty("identifikasjonsnummer")]
+    public List<IdentifikasjonsnummerDto> Identifikasjonsnummer { get; set; }
+
+    [JsonProperty("identitetsgrunnlag")]
+    public List<IdentitetsgrunnlagDto> Identitetsgrunnlag { get; set; }
+
+    [JsonProperty("innflytting")]
+    public List<InnflyttingDto> Innflytting { get; set; }
+
+    [JsonProperty("kjoenn")]
+    public List<KjoennDto> Kjoenn { get; set; }
+
+    [JsonProperty("kontaktinformasjonForDoedsbo")]
+    public List<KontaktinformasjonForDoedsboDto> KontaktinformasjonForDoedsbo { get; set; }
+
+    [JsonProperty("legitimasjonsdokument")]
+    public List<LegitimasjonsdokumentDto> Legitimasjonsdokument { get; set; }
+
+    [JsonProperty("navn")]
+    public List<NavnDto> Navn { get; set; }
+
+    [JsonProperty("opphold")]
+    public List<OppholdDto> Opphold { get; set; }
+
+    [JsonProperty("oppholdPaaSvalbard")]
+    public List<OppholdPaaSvalbardDto> OppholdPaaSvalbard { get; set; }
+
+    [JsonProperty("oppholdsadresse")]
+    public List<OppholdsadresseDto> Oppholdsadresse { get; set; }
+
+    [JsonProperty("postadresse")]
+    public List<PostadresseDto> Postadresse { get; set; }
+
+    [JsonProperty("postadresseIUtlandet")]
+    public List<PostadresseIUtlandetDto> PostadresseIUtlandet { get; set; }
+
+    [JsonProperty("preferertKontaktadresse")]
+    public List<PreferertKontaktadresseDto> PreferertKontaktadresse { get; set; }
+
+    [JsonProperty("rettsligHandleevne")]
+    public List<RettsligHandleevneDto> RettsligHandleevne { get; set; }
+
+    [JsonProperty("sivilstand")]
+    public List<SivilstandDto> Sivilstand { get; set; }
+
+    [JsonProperty("statsborgerskap")]
+    public List<StatsborgerskapDto> Statsborgerskap { get; set; }
+
+    [JsonProperty("status")]
+    public List<StatusDto> Status { get; set; }
+
+    [JsonProperty("utenlandskPersonidentifikasjon")]
+    public List<UtenlandskPersonidentifikasjonDto> UtenlandskPersonidentifikasjon { get; set; }
+
+    [JsonProperty("utflytting")]
+    public List<UtflyttingDto> Utflytting { get; set; }
+
+    [JsonProperty("utlendingsmyndighetenesIdentifikasjonsnummer")]
+    public List<UtlendingsmyndighetenesIdentifikasjonsnummerDto> UtlendingsmyndighetenesIdentifikasjonsnummer { get; set; }
+
+    [JsonProperty("vergemaalEllerFremtidsfullmakt")]
+    public List<VergemaalEllerFremtidsfullmaktDto> VergemaalEllerFremtidsfullmakt { get; set; }
+}
+
+// ── Shared sub-types ─────────────────────────────────────────────────────────
+
+[Serializable]
+public class FregPersonnavnDto
+{
+    [JsonProperty("etternavn")]
+    public string Etternavn { get; set; }
+
+    [JsonProperty("fornavn")]
+    public string Fornavn { get; set; }
+
+    [JsonProperty("mellomnavn")]
+    public string Mellomnavn { get; set; }
+}
+
+[Serializable]
+public class FregPoststedDto
+{
+    [JsonProperty("postnummer")]
+    public string Postnummer { get; set; }
+
+    [JsonProperty("poststedsnavn")]
+    public string Poststedsnavn { get; set; }
+}
+
+[Serializable]
+public class FregAdressenummerDto
+{
+    [JsonProperty("husbokstav")]
+    public string Husbokstav { get; set; }
+
+    [JsonProperty("husnummer")]
+    public string Husnummer { get; set; }
+}
+
+[Serializable]
+public class FregMatrikkelnummerDto
+{
+    [JsonProperty("bruksnummer")]
+    public int Bruksnummer { get; set; }
+
+    [JsonProperty("festenummer")]
+    public int Festenummer { get; set; }
+
+    [JsonProperty("gaardsnummer")]
+    public int Gaardsnummer { get; set; }
+
+    [JsonProperty("kommunenummer")]
+    public string Kommunenummer { get; set; }
+}
+
+[Serializable]
+public class FregMatrikkeladresseDto
+{
+    [JsonProperty("adressetilleggsnavn")]
+    public string Adressetilleggsnavn { get; set; }
+
+    [JsonProperty("bruksenhetsnummer")]
+    public string Bruksenhetsnummer { get; set; }
+
+    [JsonProperty("bruksenhetstype")]
+    public string Bruksenhetstype { get; set; }
+
+    [JsonProperty("coAdressenavn")]
+    public string CoAdressenavn { get; set; }
+
+    [JsonProperty("matrikkelnummer")]
+    public FregMatrikkelnummerDto Matrikkelnummer { get; set; }
+
+    [JsonProperty("poststed")]
+    public FregPoststedDto Poststed { get; set; }
+
+    [JsonProperty("undernummer")]
+    public int? Undernummer { get; set; }
+}
+
+[Serializable]
+public class FregVegadresseDto
+{
+    [JsonProperty("adressekode")]
+    public string Adressekode { get; set; }
+
+    [JsonProperty("adressenavn")]
+    public string Adressenavn { get; set; }
+
+    [JsonProperty("adressenummer")]
+    public FregAdressenummerDto Adressenummer { get; set; }
+
+    [JsonProperty("adressetilleggsnavn")]
+    public string Adressetilleggsnavn { get; set; }
+
+    [JsonProperty("bruksenhetsnummer")]
+    public string Bruksenhetsnummer { get; set; }
+
+    [JsonProperty("bruksenhetstype")]
+    public string Bruksenhetstype { get; set; }
+
+    [JsonProperty("coAdressenavn")]
+    public string CoAdressenavn { get; set; }
+
+    [JsonProperty("kommunenummer")]
+    public string Kommunenummer { get; set; }
+
+    [JsonProperty("poststed")]
+    public FregPoststedDto Poststed { get; set; }
+}
+
+[Serializable]
+public class FregUkjentBostedDto
+{
+    [JsonProperty("bostedskommune")]
+    public string Bostedskommune { get; set; }
+}
+
+[Serializable]
+public class FregUtenlandskAdresseDto
+{
+    [JsonProperty("adressenavn")]
+    public string Adressenavn { get; set; }
+
+    [JsonProperty("boenhet")]
+    public string Boenhet { get; set; }
+
+    [JsonProperty("byEllerStedsnavn")]
+    public string ByEllerStedsnavn { get; set; }
+
+    [JsonProperty("bygning")]
+    public string Bygning { get; set; }
+
+    [JsonProperty("coAdressenavn")]
+    public string CoAdressenavn { get; set; }
+
+    [JsonProperty("distriktsnavn")]
+    public string Distriktsnavn { get; set; }
+
+    [JsonProperty("etasjenummer")]
+    public string Etasjenummer { get; set; }
+
+    [JsonProperty("landkode")]
+    public string Landkode { get; set; }
+
+    [JsonProperty("postboks")]
+    public string Postboks { get; set; }
+
+    [JsonProperty("postkode")]
+    public string Postkode { get; set; }
+
+    [JsonProperty("region")]
+    public string Region { get; set; }
+}
+
+// Person without folkeregister identifier — two variants (one uses "navn", one uses "personnavn")
+[Serializable]
+public class FregPersonUtenIdNavnDto
+{
+    [JsonProperty("foedselsdato")]
+    public string Foedselsdato { get; set; }
+
+    [JsonProperty("kjoenn")]
+    public string Kjoenn { get; set; }
+
+    [JsonProperty("navn")]
+    public FregPersonnavnDto Navn { get; set; }
+
+    [JsonProperty("statsborgerskap")]
+    public string Statsborgerskap { get; set; }
+}
+
+[Serializable]
+public class FregPersonUtenIdPersonnavnDto
+{
+    [JsonProperty("foedselsdato")]
+    public string Foedselsdato { get; set; }
+
+    [JsonProperty("kjoenn")]
+    public string Kjoenn { get; set; }
+
+    [JsonProperty("personnavn")]
+    public FregPersonnavnDto Personnavn { get; set; }
+
+    [JsonProperty("statsborgerskap")]
+    public List<string> Statsborgerskap { get; set; }
+}
+
+// ── Part: adressebeskyttelse ─────────────────────────────────────────────────
+
+[Serializable]
+public class AdressebeskyttelseDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("graderingsnivaa")]
+    public string Graderingsnivaa { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: bibehold ───────────────────────────────────────────────────────────
+
+[Serializable]
+public class BibeholdDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("bibeholdstatus")]
+    public string Bibeholdstatus { get; set; }
+
+    [JsonProperty("datoForBibehold")]
+    public string DatoForBibehold { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: bostedsadresse ─────────────────────────────────────────────────────
+
+[Serializable]
+public class BostedsadresseDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("adresseIdentifikatorFraMatrikkelen")]
+    public string AdresseIdentifikatorFraMatrikkelen { get; set; }
+
+    [JsonProperty("adressegradering")]
+    public string Adressegradering { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("flyttedato")]
+    public string Flyttedato { get; set; }
+
+    [JsonProperty("grunnkrets")]
+    public int? Grunnkrets { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("kirkekrets")]
+    public int? Kirkekrets { get; set; }
+
+    [JsonProperty("matrikkeladresse")]
+    public FregMatrikkeladresseDto Matrikkeladresse { get; set; }
+
+    [JsonProperty("naerAdresseIdentifikatorFraMatrikkelen")]
+    public string NaerAdresseIdentifikatorFraMatrikkelen { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("skolekrets")]
+    public int? Skolekrets { get; set; }
+
+    [JsonProperty("stemmekrets")]
+    public int? Stemmekrets { get; set; }
+
+    [JsonProperty("ukjentBosted")]
+    public FregUkjentBostedDto UkjentBosted { get; set; }
+
+    [JsonProperty("vegadresse")]
+    public FregVegadresseDto Vegadresse { get; set; }
+}
+
+// ── Part: brukAvSamiskSpraak ─────────────────────────────────────────────────
+
+[Serializable]
+public class BrukAvSamiskSpraakDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("spraak")]
+    public List<string> Spraak { get; set; }
+}
+
+// ── Part: deltBosted ─────────────────────────────────────────────────────────
+
+[Serializable]
+public class DeltBostedDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("adresseIdentifikatorFraMatrikkelen")]
+    public string AdresseIdentifikatorFraMatrikkelen { get; set; }
+
+    [JsonProperty("adressegradering")]
+    public string Adressegradering { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("matrikkeladresse")]
+    public FregMatrikkeladresseDto Matrikkeladresse { get; set; }
+
+    [JsonProperty("naerAdresseIdentifikatorFraMatrikkelen")]
+    public string NaerAdresseIdentifikatorFraMatrikkelen { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("sluttdatoForKontrakt")]
+    public string SluttdatoForKontrakt { get; set; }
+
+    [JsonProperty("startdatoForKontrakt")]
+    public string StartdatoForKontrakt { get; set; }
+
+    [JsonProperty("ukjentBosted")]
+    public FregUkjentBostedDto UkjentBosted { get; set; }
+
+    [JsonProperty("vegadresse")]
+    public FregVegadresseDto Vegadresse { get; set; }
+}
+
+// ── Part: doedsfall ──────────────────────────────────────────────────────────
+
+[Serializable]
+public class DoedsfallDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("doedsdato")]
+    public string Doedsdato { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: falskIdentitet ─────────────────────────────────────────────────────
+
+[Serializable]
+public class FalskIdentitetRettIdentitetVedOpplysningerDto
+{
+    [JsonProperty("foedselsdato")]
+    public string Foedselsdato { get; set; }
+
+    [JsonProperty("kjoenn")]
+    public string Kjoenn { get; set; }
+
+    [JsonProperty("personnavn")]
+    public FregPersonnavnDto Personnavn { get; set; }
+
+    [JsonProperty("statsborgerskap")]
+    public List<string> Statsborgerskap { get; set; }
+}
+
+[Serializable]
+public class FalskIdentitetDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erFalsk")]
+    public bool ErFalsk { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("rettIdentitetErUkjent")]
+    public bool? RettIdentitetErUkjent { get; set; }
+
+    [JsonProperty("rettIdentitetVedIdentifikasjonsnummer")]
+    public string RettIdentitetVedIdentifikasjonsnummer { get; set; }
+
+    [JsonProperty("rettIdentitetVedOpplysninger")]
+    public FalskIdentitetRettIdentitetVedOpplysningerDto RettIdentitetVedOpplysninger { get; set; }
+}
+
+// ── Part: familierelasjon ─────────────────────────────────────────────────────
+
+[Serializable]
+public class FamilierelasjonsDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("minRolleForPerson")]
+    public string MinRolleForPerson { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("relatertPerson")]
+    public string RelatertPerson { get; set; }
+
+    [JsonProperty("relatertPersonUtenFolkeregisteridentifikator")]
+    public FregPersonUtenIdNavnDto RelatertPersonUtenFolkeregisteridentifikator { get; set; }
+
+    [JsonProperty("relatertPersonsRolle")]
+    public string RelatertPersonsRolle { get; set; }
+}
+
+// ── Part: foedsel ─────────────────────────────────────────────────────────────
+
+[Serializable]
+public class FoedselDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("foedekommuneINorge")]
+    public string FoedekommuneINorge { get; set; }
+
+    [JsonProperty("foedeland")]
+    public string Foedeland { get; set; }
+
+    [JsonProperty("foedested")]
+    public string Foedested { get; set; }
+
+    [JsonProperty("foedselsaar")]
+    public string Foedselsaar { get; set; }
+
+    [JsonProperty("foedselsdato")]
+    public string Foedselsdato { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: foedselINorge ───────────────────────────────────────────────────────
+
+[Serializable]
+public class FoedselINorgeDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("foedselsinstitusjonsnavn")]
+    public string Foedselsinstitusjonsnavn { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("rekkefoelgenummer")]
+    public int? Rekkefoelgenummer { get; set; }
+}
+
+// ── Part: foreldreansvar ──────────────────────────────────────────────────────
+
+[Serializable]
+public class ForeldreansvarDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("ansvar")]
+    public string Ansvar { get; set; }
+
+    [JsonProperty("ansvarlig")]
+    public string Ansvarlig { get; set; }
+
+    [JsonProperty("ansvarligOrganisasjon")]
+    public string AnsvarligOrganisasjon { get; set; }
+
+    [JsonProperty("ansvarligUtenIdentifikator")]
+    public FregPersonUtenIdNavnDto AnsvarligUtenIdentifikator { get; set; }
+
+    [JsonProperty("ansvarssubjekt")]
+    public string Ansvarssubjekt { get; set; }
+
+    [JsonProperty("ansvarssubjektUtenIdentifikator")]
+    public FregPersonUtenIdNavnDto AnsvarssubjektUtenIdentifikator { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: forholdTilSametingetsValgmanntall ───────────────────────────────────
+
+[Serializable]
+public class ForholdTilSametingetsValgmanntallDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("forhold")]
+    public string Forhold { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("vedtaksdato")]
+    public string Vedtaksdato { get; set; }
+}
+
+// ── Part: fratattRettsligHandleevne ───────────────────────────────────────────
+
+[Serializable]
+public class FratattRettsligHandleevneDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: identifikasjonsnummer ───────────────────────────────────────────────
+
+[Serializable]
+public class IdentifikasjonsnummerDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("foedselsEllerDNummer")]
+    public string FoedselsEllerDNummer { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("identifikatortype")]
+    public string Identifikatortype { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("status")]
+    public string Status { get; set; }
+}
+
+// ── Part: identitetsgrunnlag ──────────────────────────────────────────────────
+
+[Serializable]
+public class IdentitetsgrunnlagDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("identitetsgrunnlagstatus")]
+    public string Identitetsgrunnlagstatus { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: innflytting ─────────────────────────────────────────────────────────
+
+[Serializable]
+public class InnflyttingDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("fraflyttingsland")]
+    public string Fraflyttingsland { get; set; }
+
+    [JsonProperty("fraflyttingsstedIUtlandet")]
+    public string FraflyttingsstedIUtlandet { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: kjoenn ──────────────────────────────────────────────────────────────
+
+[Serializable]
+public class KjoennDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("kjoenn")]
+    public string Kjoenn { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+}
+
+// ── Part: kontaktinformasjonForDoedsbo ────────────────────────────────────────
+
+[Serializable]
+public class KontaktinformasjonForDoedsboAdresseDto
+{
+    [JsonProperty("adresselinje")]
+    public List<string> Adresselinje { get; set; }
+
+    [JsonProperty("landkode")]
+    public string Landkode { get; set; }
+
+    [JsonProperty("postnummer")]
+    public string Postnummer { get; set; }
+
+    [JsonProperty("poststedsnavn")]
+    public string Poststedsnavn { get; set; }
+}
+
+[Serializable]
+public class KontaktinformasjonForDoedsboAdvokatDto
+{
+    [JsonProperty("organisasjonsnavn")]
+    public string Organisasjonsnavn { get; set; }
+
+    [JsonProperty("organisasjonsnummer")]
+    public string Organisasjonsnummer { get; set; }
+
+    [JsonProperty("personnavn")]
+    public FregPersonnavnDto Personnavn { get; set; }
+}
+
+[Serializable]
+public class KontaktinformasjonForDoedsboOrganisasjonDto
+{
+    [JsonProperty("kontaktpersonnavn")]
+    public FregPersonnavnDto Kontaktpersonnavn { get; set; }
+
+    [JsonProperty("organisasjonsnavn")]
+    public string Organisasjonsnavn { get; set; }
+
+    [JsonProperty("organisasjonsnummer")]
+    public string Organisasjonsnummer { get; set; }
+}
+
+[Serializable]
+public class KontaktinformasjonForDoedsboPersonDto
+{
+    [JsonProperty("foedselsEllerDNummer")]
+    public string FoedselsEllerDNummer { get; set; }
+
+    [JsonProperty("foedselsdato")]
+    public string Foedselsdato { get; set; }
+
+    [JsonProperty("personnavn")]
+    public FregPersonnavnDto Personnavn { get; set; }
+}
+
+[Serializable]
+public class KontaktinformasjonForDoedsboDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("adresse")]
+    public KontaktinformasjonForDoedsboAdresseDto Adresse { get; set; }
+
+    [JsonProperty("advokat")]
+    public KontaktinformasjonForDoedsboAdvokatDto Advokat { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("attestutstedelsesdato")]
+    public string Attestutstedelsesdato { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("organisasjon")]
+    public KontaktinformasjonForDoedsboOrganisasjonDto Organisasjon { get; set; }
+
+    [JsonProperty("person")]
+    public KontaktinformasjonForDoedsboPersonDto Person { get; set; }
+
+    [JsonProperty("skifteform")]
+    public string Skifteform { get; set; }
+}
+
+// ── Part: legitimasjonsdokument ───────────────────────────────────────────────
+
+[Serializable]
+public class DokumentkontrollDto
+{
+    [JsonProperty("dokumentkontrollstatus")]
+    public string Dokumentkontrollstatus { get; set; }
+
+    [JsonProperty("dokumentkontrolltidspunkt")]
+    public DateTimeOffset? Dokumentkontrolltidspunkt { get; set; }
+}
+
+[Serializable]
+public class LegitimasjonsdokumentDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("dokumentkontroll")]
+    public DokumentkontrollDto Dokumentkontroll { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldigFra")]
+    public string GyldigFra { get; set; }
+
+    [JsonProperty("gyldigTil")]
+    public string GyldigTil { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("identifikasjonsdokumentnummer")]
+    public string Identifikasjonsdokumentnummer { get; set; }
+
+    [JsonProperty("identifikasjonsdokumenttype")]
+    public string Identifikasjonsdokumenttype { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("utstederland")]
+    public string Utstederland { get; set; }
+
+    [JsonProperty("utstedernavn")]
+    public string Utstedernavn { get; set; }
+}
+
+// ── Part: navn ────────────────────────────────────────────────────────────────
+
+[Serializable]
+public class NavnDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("etternavn")]
+    public string Etternavn { get; set; }
+
+    [JsonProperty("forkortetNavn")]
+    public string ForkortetNavn { get; set; }
+
+    [JsonProperty("fornavn")]
+    public string Fornavn { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("mellomnavn")]
+    public string Mellomnavn { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("originaltNavn")]
+    public FregPersonnavnDto OriginaltNavn { get; set; }
+}
+
+// ── Part: opphold ─────────────────────────────────────────────────────────────
+
+[Serializable]
+public class OppholdDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("oppholdFra")]
+    public string OppholdFra { get; set; }
+
+    [JsonProperty("oppholdTil")]
+    public string OppholdTil { get; set; }
+
+    [JsonProperty("oppholdstillatelse")]
+    public string Oppholdstillatelse { get; set; }
+}
+
+// ── Part: oppholdPaaSvalbard ──────────────────────────────────────────────────
+
+[Serializable]
+public class OppholdPaaSvalbardDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("antallTidligereOpphold")]
+    public int? AntallTidligereOpphold { get; set; }
+
+    [JsonProperty("antattOppholdsvarighet")]
+    public string AntattOppholdsvarighet { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("fraflyttingskommunenummer")]
+    public string Fraflyttingskommunenummer { get; set; }
+
+    [JsonProperty("fraflyttingsland")]
+    public string Fraflyttingsland { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("sluttdato")]
+    public string Sluttdato { get; set; }
+
+    [JsonProperty("startdato")]
+    public string Startdato { get; set; }
+}
+
+// ── Part: oppholdsadresse ─────────────────────────────────────────────────────
+
+[Serializable]
+public class OppholdsadresseDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("adresseIdentifikatorFraMatrikkelen")]
+    public string AdresseIdentifikatorFraMatrikkelen { get; set; }
+
+    [JsonProperty("adressegradering")]
+    public string Adressegradering { get; set; }
+
+    [JsonProperty("adressenErUkjent")]
+    public bool? AdressenErUkjent { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("matrikkeladresse")]
+    public FregMatrikkeladresseDto Matrikkeladresse { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("oppholdAnnetSted")]
+    public string OppholdAnnetSted { get; set; }
+
+    [JsonProperty("oppholdsadressedato")]
+    public string Oppholdsadressedato { get; set; }
+
+    [JsonProperty("utenlandskAdresse")]
+    public FregUtenlandskAdresseDto UtenlandskAdresse { get; set; }
+
+    [JsonProperty("vegadresse")]
+    public FregVegadresseDto Vegadresse { get; set; }
+}
+
+// ── Part: postadresse ─────────────────────────────────────────────────────────
+
+[Serializable]
+public class PostadresseIFrittFormatDto
+{
+    [JsonProperty("adresselinje")]
+    public List<string> Adresselinje { get; set; }
+
+    [JsonProperty("poststed")]
+    public FregPoststedDto Poststed { get; set; }
+}
+
+[Serializable]
+public class PostboksadresseDto
+{
+    [JsonProperty("postboks")]
+    public string Postboks { get; set; }
+
+    [JsonProperty("postbokseier")]
+    public string Postbokseier { get; set; }
+
+    [JsonProperty("poststed")]
+    public FregPoststedDto Poststed { get; set; }
+}
+
+[Serializable]
+public class PostadresseDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("adresseIdentifikatorFraMatrikkelen")]
+    public string AdresseIdentifikatorFraMatrikkelen { get; set; }
+
+    [JsonProperty("adressegradering")]
+    public string Adressegradering { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("postadresseIFrittFormat")]
+    public PostadresseIFrittFormatDto PostadresseIFrittFormat { get; set; }
+
+    [JsonProperty("postboksadresse")]
+    public PostboksadresseDto Postboksadresse { get; set; }
+
+    [JsonProperty("vegadresse")]
+    public FregVegadresseDto Vegadresse { get; set; }
+}
+
+// ── Part: postadresseIUtlandet ────────────────────────────────────────────────
+
+[Serializable]
+public class UtenlandskAdresseIFrittFormatDto
+{
+    [JsonProperty("adresselinje")]
+    public List<string> Adresselinje { get; set; }
+
+    [JsonProperty("byEllerStedsnavn")]
+    public string ByEllerStedsnavn { get; set; }
+
+    [JsonProperty("landkode")]
+    public string Landkode { get; set; }
+
+    [JsonProperty("postkode")]
+    public string Postkode { get; set; }
+}
+
+[Serializable]
+public class PostadresseIUtlandetDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("adressegradering")]
+    public string Adressegradering { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("utenlandskAdresse")]
+    public FregUtenlandskAdresseDto UtenlandskAdresse { get; set; }
+
+    [JsonProperty("utenlandskAdresseIFrittFormat")]
+    public UtenlandskAdresseIFrittFormatDto UtenlandskAdresseIFrittFormat { get; set; }
+}
+
+// ── Part: preferertKontaktadresse ─────────────────────────────────────────────
+
+[Serializable]
+public class KontaktadresseIFrittFormatDto
+{
+    [JsonProperty("adresselinje")]
+    public List<string> Adresselinje { get; set; }
+
+    [JsonProperty("landkode")]
+    public string Landkode { get; set; }
+}
+
+[Serializable]
+public class PreferertKontaktadresseDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("adressegradering")]
+    public string Adressegradering { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("kontaktadresseIFrittFormat")]
+    public KontaktadresseIFrittFormatDto KontaktadresseIFrittFormat { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("valg")]
+    public string Valg { get; set; }
+}
+
+// ── Part: rettsligHandleevne ──────────────────────────────────────────────────
+
+[Serializable]
+public class RettsligHandleevneDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("rettsligHandleevneomfang")]
+    public string RettsligHandleevneomfang { get; set; }
+}
+
+// ── Part: sivilstand ──────────────────────────────────────────────────────────
+
+[Serializable]
+public class SivilstandDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("kommune")]
+    public string Kommune { get; set; }
+
+    [JsonProperty("myndighet")]
+    public string Myndighet { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("relatertVedSivilstand")]
+    public string RelatertVedSivilstand { get; set; }
+
+    [JsonProperty("sivilstand")]
+    public string Sivilstand { get; set; }
+
+    [JsonProperty("sivilstandsdato")]
+    public string Sivilstandsdato { get; set; }
+
+    [JsonProperty("sted")]
+    public string Sted { get; set; }
+
+    [JsonProperty("utland")]
+    public string Utland { get; set; }
+}
+
+// ── Part: statsborgerskap ─────────────────────────────────────────────────────
+
+[Serializable]
+public class StatsborgerskapDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("ervervsdato")]
+    public string Ervervsdato { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("statsborgerskap")]
+    public string Statsborgerskap { get; set; }
+}
+
+// ── Part: status ──────────────────────────────────────────────────────────────
+
+[Serializable]
+public class StatusDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("status")]
+    public string Status { get; set; }
+}
+
+// ── Part: utenlandskPersonidentifikasjon ──────────────────────────────────────
+
+[Serializable]
+public class UtenlandskPersonidentifikasjonDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("identifikasjonsnummer")]
+    public string Identifikasjonsnummer { get; set; }
+
+    [JsonProperty("identifikasjonsnummertype")]
+    public string Identifikasjonsnummertype { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("utstederland")]
+    public string Utstederland { get; set; }
+}
+
+// ── Part: utflytting ──────────────────────────────────────────────────────────
+
+[Serializable]
+public class UtflyttingDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("tilflyttingsland")]
+    public string Tilflyttingsland { get; set; }
+
+    [JsonProperty("tilflyttingsstedIUtlandet")]
+    public string TilflyttingsstedIUtlandet { get; set; }
+
+    [JsonProperty("utflyttingsdato")]
+    public string Utflyttingsdato { get; set; }
+}
+
+// ── Part: utlendingsmyndighetenesIdentifikasjonsnummer ────────────────────────
+
+[Serializable]
+public class UtlendingsmyndighetenesIdentifikasjonsnummerDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("identifikasjonsnummer")]
+    public string Identifikasjonsnummer { get; set; }
+
+    [JsonProperty("identifikasjonsnummertype")]
+    public string Identifikasjonsnummertype { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("utstederland")]
+    public string Utstederland { get; set; }
+}
+
+// ── Part: vergemaalEllerFremtidsfullmakt ──────────────────────────────────────
+
+[Serializable]
+public class VergeTjenesteDto
+{
+    [JsonProperty("vergeTjenesteoppgave")]
+    public string VergeTjenesteoppgave { get; set; }
+
+    [JsonProperty("vergeTjenestevirksomhet")]
+    public string VergeTjenestevirksomhet { get; set; }
+}
+
+[Serializable]
+public class VergeDto
+{
+    [JsonProperty("foedselsEllerDNummer")]
+    public string FoedselsEllerDNummer { get; set; }
+
+    [JsonProperty("navn")]
+    public FregPersonnavnDto Navn { get; set; }
+
+    [JsonProperty("navnFoedselsdato")]
+    public FregPersonUtenIdPersonnavnDto NavnFoedselsdato { get; set; }
+
+    [JsonProperty("omfang")]
+    public string Omfang { get; set; }
+
+    [JsonProperty("omfangetErInnenPersonligOmraade")]
+    public bool? OmfangetErInnenPersonligOmraade { get; set; }
+
+    [JsonProperty("tjenesteomraade")]
+    public List<VergeTjenesteDto> Tjenesteomraade { get; set; }
+}
+
+[Serializable]
+public class VergemaalEllerFremtidsfullmaktDto
+{
+    [JsonProperty("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonProperty("ajourholdstidspunkt")]
+    public DateTimeOffset? Ajourholdstidspunkt { get; set; }
+
+    [JsonProperty("embete")]
+    public string Embete { get; set; }
+
+    [JsonProperty("erGjeldende")]
+    public bool ErGjeldende { get; set; }
+
+    [JsonProperty("gyldighetstidspunkt")]
+    public DateTimeOffset? Gyldighetstidspunkt { get; set; }
+
+    [JsonProperty("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonProperty("opphoerstidspunkt")]
+    public DateTimeOffset? Opphoerstidspunkt { get; set; }
+
+    [JsonProperty("verge")]
+    public VergeDto Verge { get; set; }
+
+    [JsonProperty("vergemaaltype")]
+    public string Vergemaaltype { get; set; }
+}

--- a/src/Dan.Plugin.Skatteetaten/Models/Dtos/MvaMeldingsOpplysningDto.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/Dtos/MvaMeldingsOpplysningDto.cs
@@ -1,0 +1,184 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Dan.Plugin.Skatteetaten.Models.Dtos;
+
+[Serializable]
+public class MvaMeldingsOpplysningDto
+{
+    public MvaMeldingsOpplysningDto(VATReportModel model)
+    {
+        Levert = model.levert;
+        ForespurteOrganisasjon = model.forespurteOrganisasjon;
+        MvaAlminneligNaering = new MvaAlminneligNaeringDto(model.mvaAlminneligNaering);
+    }
+
+    [JsonProperty("levert")]
+    public DateTime Levert { get; set; }
+
+    [JsonProperty("forespurteOrganisasjon")]
+    public string ForespurteOrganisasjon { get; set; }
+
+    [JsonProperty("mvaAlminneligNaering")]
+    public MvaAlminneligNaeringDto MvaAlminneligNaering { get; set; }
+}
+
+[Serializable]
+public class MvaAlminneligNaeringDto
+{
+    public MvaAlminneligNaeringDto(MvaAlminneligNaering model)
+    {
+        Skattemeldingsplikt = model.skattemeldingsplikt != null ? new SkattemeldingspliktDto(model.skattemeldingsplikt) : null;
+        AnsvarligForMvaMelding = model.ansvarligForMvaMelding != null ? new AnsvarligForMvaMeldingDto(model.ansvarligForMvaMelding) : null;
+        SamletFastsattOgReskontrofoertForTermin = model.samletFastsattOgReskontrofoertForTermin?
+            .Select(t => new SamletFastsattDto(t))
+            .ToList() ?? new List<SamletFastsattDto>();
+    }
+
+    [JsonProperty("skattemeldingsplikt")]
+    public SkattemeldingspliktDto Skattemeldingsplikt { get; set; }
+
+    [JsonProperty("ansvarligForMvaMelding")]
+    public AnsvarligForMvaMeldingDto AnsvarligForMvaMelding { get; set; }
+
+    [JsonProperty("samletFastsattOgReskontrofoertForTermin")]
+    public List<SamletFastsattDto> SamletFastsattOgReskontrofoertForTermin { get; set; }
+}
+
+[Serializable]
+public class SkattemeldingspliktDto
+{
+    public SkattemeldingspliktDto(Skattemeldingsplikt model)
+    {
+        Termintype = model.termintype;
+        FoersteTermin = model.foersteTermin != null ? new TerminDto(model.foersteTermin.termin, model.foersteTermin.aar) : null;
+        SisteTermin = model.sisteTermin != null ? new TerminDto(model.sisteTermin.termin, model.sisteTermin.aar) : null;
+    }
+
+    [JsonProperty("termintype")]
+    public string Termintype { get; set; }
+
+    [JsonProperty("foersteTermin")]
+    public TerminDto FoersteTermin { get; set; }
+
+    [JsonProperty("sisteTermin")]
+    public TerminDto SisteTermin { get; set; }
+}
+
+[Serializable]
+public class TerminDto
+{
+    public TerminDto(string termin, string aar)
+    {
+        Termin = termin;
+        Aar = aar;
+    }
+
+    [JsonProperty("termin")]
+    public string Termin { get; set; }
+
+    [JsonProperty("aar")]
+    public string Aar { get; set; }
+}
+
+[Serializable]
+public class AnsvarligForMvaMeldingDto
+{
+    public AnsvarligForMvaMeldingDto(AnsvarligForMvaMelding model)
+    {
+        Organisasjonsnummer = model.organisasjonsnummer;
+        Organisasjonsnavn = model.oragnisasjonsnavn;
+    }
+
+    [JsonProperty("organisasjonsnummer")]
+    public int Organisasjonsnummer { get; set; }
+
+    [JsonProperty("organisasjonsnavn")]
+    public string Organisasjonsnavn { get; set; }
+}
+
+[Serializable]
+public class SamletFastsattDto
+{
+    public SamletFastsattDto(SamletFastsattOgReskontrofoertForTermin model)
+    {
+        GjelderTermin = model.gjelderTermin != null ? new TerminDto(model.gjelderTermin.termin, model.gjelderTermin.aar) : null;
+        FastsettingsperiodeStatus = model.fastsettingsperiodeStatus;
+        ErMyndighetsfastsatt = model.erMyndighetsfastsatt;
+        GrunnMyndighetsfastsatt = model.grunnMyndighetsfastsatt;
+        MvaAvgift = model.mvaAvgift != null ? new MvaAvgiftDto(model.mvaAvgift) : null;
+        MvaGrunnlag = model.mvaGrunnlag != null ? new MvaGrunnlagDto(model.mvaGrunnlag) : null;
+    }
+
+    [JsonProperty("gjelderTermin")]
+    public TerminDto GjelderTermin { get; set; }
+
+    [JsonProperty("fastsettingsperiodeStatus")]
+    public string FastsettingsperiodeStatus { get; set; }
+
+    [JsonProperty("erMyndighetsfastsatt")]
+    public bool? ErMyndighetsfastsatt { get; set; }
+
+    [JsonProperty("grunnMyndighetsfastsatt")]
+    public string GrunnMyndighetsfastsatt { get; set; }
+
+    [JsonProperty("mvaAvgift")]
+    public MvaAvgiftDto MvaAvgift { get; set; }
+
+    [JsonProperty("mvaGrunnlag")]
+    public MvaGrunnlagDto MvaGrunnlag { get; set; }
+}
+
+[Serializable]
+public class MvaAvgiftDto
+{
+    public MvaAvgiftDto(MvaAvgift model)
+    {
+        InnlandOmsetningUttakHoeySats = model.innlandOmsetningUttakHoeySats;
+        InnlandOmsetningUttakMiddelsSats = model.innlandOmsetningUttakMiddelsSats;
+        InnlandOmsetningUttakLavSats = model.innlandOmsetningUttakLavSats;
+        FradragInnlandInngaaendeHoeySats = model.fradragInnlandInngaaendeHoeySats;
+        FradragInnlandInngaaendeMiddelsSats = model.fradragInnlandInngaaendeMiddelsSats;
+        FradragInnlandInngaaendeLavSats = model.fradragInnlandInngaaendeLavSats;
+    }
+
+    [JsonProperty("innlandOmsetningUttakHoeySats")]
+    public int InnlandOmsetningUttakHoeySats { get; set; }
+
+    [JsonProperty("innlandOmsetningUttakMiddelsSats")]
+    public int InnlandOmsetningUttakMiddelsSats { get; set; }
+
+    [JsonProperty("innlandOmsetningUttakLavSats")]
+    public int InnlandOmsetningUttakLavSats { get; set; }
+
+    [JsonProperty("fradragInnlandInngaaendeHoeySats")]
+    public int FradragInnlandInngaaendeHoeySats { get; set; }
+
+    [JsonProperty("fradragInnlandInngaaendeMiddelsSats")]
+    public int FradragInnlandInngaaendeMiddelsSats { get; set; }
+
+    [JsonProperty("fradragInnlandInngaaendeLavSats")]
+    public int FradragInnlandInngaaendeLavSats { get; set; }
+}
+
+[Serializable]
+public class MvaGrunnlagDto
+{
+    public MvaGrunnlagDto(MvaGrunnlag model)
+    {
+        InnlandOmsetningUttakHoeySats = model.innlandOmsetningUttakHoeySats;
+        InnlandOmsetningUttakMiddelsSats = model.innlandOmsetningUttakMiddelsSats;
+        InnlandOmsetningUttakLavSats = model.innlandOmsetningUttakLavSats;
+    }
+
+    [JsonProperty("innlandOmsetningUttakHoeySats")]
+    public int InnlandOmsetningUttakHoeySats { get; set; }
+
+    [JsonProperty("innlandOmsetningUttakMiddelsSats")]
+    public int InnlandOmsetningUttakMiddelsSats { get; set; }
+
+    [JsonProperty("innlandOmsetningUttakLavSats")]
+    public int InnlandOmsetningUttakLavSats { get; set; }
+}

--- a/src/Dan.Plugin.Skatteetaten/Models/Dtos/MvaMeldingsOpplysningDto.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/Dtos/MvaMeldingsOpplysningDto.cs
@@ -12,7 +12,7 @@ public class MvaMeldingsOpplysningDto
     {
         Levert = model.levert;
         ForespurteOrganisasjon = model.forespurteOrganisasjon;
-        MvaAlminneligNaering = new MvaAlminneligNaeringDto(model.mvaAlminneligNaering);
+        MvaAlminneligNaering = model.mvaAlminneligNaering != null ? new MvaAlminneligNaeringDto(model.mvaAlminneligNaering) : null;
     }
 
     [JsonProperty("levert")]

--- a/src/Dan.Plugin.Skatteetaten/Models/Dtos/OppdragUtenlandskeVirksomheterDto.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/Dtos/OppdragUtenlandskeVirksomheterDto.cs
@@ -10,7 +10,7 @@ public class OppdragUtenlandskeVirksomheterDto
     public OppdragUtenlandskeVirksomheterDto(OppdragUtenlandskeVirksomheterModel model)
     {
         ForespurteOrganisasjon = model.forespurteOrganisasjon;
-        Oppdrag = new OppdragAntallDto(model.oppdrag);
+        Oppdrag = model.oppdrag != null ? new OppdragAntallDto(model.oppdrag) : null;
     }
 
     [JsonProperty("forespurteOrganisasjon")]

--- a/src/Dan.Plugin.Skatteetaten/Models/Dtos/OppdragUtenlandskeVirksomheterDto.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/Dtos/OppdragUtenlandskeVirksomheterDto.cs
@@ -1,0 +1,41 @@
+using Dan.Plugin.Skatteetaten.Models.OppdragUtenlandskeVirksomheter;
+using Newtonsoft.Json;
+using System;
+
+namespace Dan.Plugin.Skatteetaten.Models.Dtos;
+
+[Serializable]
+public class OppdragUtenlandskeVirksomheterDto
+{
+    public OppdragUtenlandskeVirksomheterDto(OppdragUtenlandskeVirksomheterModel model)
+    {
+        ForespurteOrganisasjon = model.forespurteOrganisasjon;
+        Oppdrag = new OppdragAntallDto(model.oppdrag);
+    }
+
+    [JsonProperty("forespurteOrganisasjon")]
+    public string ForespurteOrganisasjon { get; set; }
+
+    [JsonProperty("oppdrag")]
+    public OppdragAntallDto Oppdrag { get; set; }
+}
+
+[Serializable]
+public class OppdragAntallDto
+{
+    public OppdragAntallDto(OppdragAntall oppdrag)
+    {
+        AntallAktiveOppdragSomArbeidsgiver = oppdrag.antallAktiveOppdragSomArbeidsgiver;
+        AntallAktiveArbeidstakere = oppdrag.antallAktiveArbeidstakere;
+        AntallRegistrerteOppdragSomOppdragsgiver = oppdrag.antallRegistrerteOppdragSomOppdragsgiver;
+    }
+
+    [JsonProperty("antallAktiveOppdragSomArbeidsgiver")]
+    public int AntallAktiveOppdragSomArbeidsgiver { get; set; }
+
+    [JsonProperty("antallAktiveArbeidstakere")]
+    public int AntallAktiveArbeidstakere { get; set; }
+
+    [JsonProperty("antallRegistrerteOppdragSomOppdragsgiver")]
+    public int AntallRegistrerteOppdragSomOppdragsgiver { get; set; }
+}

--- a/src/Dan.Plugin.Skatteetaten/Models/Dtos/RestanserV2Dto.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/Dtos/RestanserV2Dto.cs
@@ -1,0 +1,77 @@
+using Dan.Plugin.Skatteetaten.Models.Arrears;
+using Newtonsoft.Json;
+using System;
+
+namespace Dan.Plugin.Skatteetaten.Models.Dtos;
+
+[Serializable]
+public class RestanserV2Dto
+{
+    public RestanserV2Dto(ArrearsModel model)
+    {
+        Levert = model.levert;
+        ForespurteOrganisasjon = model.forespurteOrganisasjon;
+        Restanser = new RestanserDto(model.restanser);
+    }
+
+    [JsonProperty("levert")]
+    public DateTime Levert { get; set; }
+
+    [JsonProperty("forespurteOrganisasjon")]
+    public string ForespurteOrganisasjon { get; set; }
+
+    [JsonProperty("restanser")]
+    public RestanserDto Restanser { get; set; }
+}
+
+[Serializable]
+public class RestanserDto
+{
+    public RestanserDto(Restanser restanser)
+    {
+        Arbeidsgiveravgift = new RestanserKategoriDto(restanser.arbeidsgiveravgift);
+        Forskuddstrekk = new RestanserKategoriDto(restanser.forskuddstrekk);
+        Forskuddsskatt = new RestanserKategoriDto(restanser.forskuddsskatt);
+        Restskatt = new RestanserKategoriDto(restanser.restskatt);
+        Gebyr = new RestanserKategoriDto(restanser.gebyr);
+        Merverdiavgift = new RestanserKategoriDto(restanser.merverdiavgift);
+    }
+
+    [JsonProperty("arbeidsgiveravgift")]
+    public RestanserKategoriDto Arbeidsgiveravgift { get; set; }
+
+    [JsonProperty("forskuddstrekk")]
+    public RestanserKategoriDto Forskuddstrekk { get; set; }
+
+    [JsonProperty("forskuddsskatt")]
+    public RestanserKategoriDto Forskuddsskatt { get; set; }
+
+    [JsonProperty("restskatt")]
+    public RestanserKategoriDto Restskatt { get; set; }
+
+    [JsonProperty("gebyr")]
+    public RestanserKategoriDto Gebyr { get; set; }
+
+    [JsonProperty("merverdiavgift")]
+    public RestanserKategoriDto Merverdiavgift { get; set; }
+}
+
+[Serializable]
+public class RestanserKategoriDto
+{
+    public RestanserKategoriDto(RestanserKategori kategori)
+    {
+        ForfaltOgUbetalt = kategori.forfaltOgUbetalt;
+        ForfaltOgUbetaltRenter = kategori.forfaltOgUbetaltRenter;
+        ForfaltOgUbetaltKrav = kategori.forfaltOgUbetaltKrav;
+    }
+
+    [JsonProperty("forfaltOgUbetalt")]
+    public decimal ForfaltOgUbetalt { get; set; }
+
+    [JsonProperty("forfaltOgUbetaltRenter")]
+    public decimal ForfaltOgUbetaltRenter { get; set; }
+
+    [JsonProperty("forfaltOgUbetaltKrav")]
+    public decimal ForfaltOgUbetaltKrav { get; set; }
+}

--- a/src/Dan.Plugin.Skatteetaten/Models/Dtos/RestanserV2Dto.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/Dtos/RestanserV2Dto.cs
@@ -11,7 +11,7 @@ public class RestanserV2Dto
     {
         Levert = model.levert;
         ForespurteOrganisasjon = model.forespurteOrganisasjon;
-        Restanser = new RestanserDto(model.restanser);
+        Restanser = model.restanser != null ? new RestanserDto(model.restanser) : null;
     }
 
     [JsonProperty("levert")]
@@ -29,12 +29,12 @@ public class RestanserDto
 {
     public RestanserDto(Restanser restanser)
     {
-        Arbeidsgiveravgift = new RestanserKategoriDto(restanser.arbeidsgiveravgift);
-        Forskuddstrekk = new RestanserKategoriDto(restanser.forskuddstrekk);
-        Forskuddsskatt = new RestanserKategoriDto(restanser.forskuddsskatt);
-        Restskatt = new RestanserKategoriDto(restanser.restskatt);
-        Gebyr = new RestanserKategoriDto(restanser.gebyr);
-        Merverdiavgift = new RestanserKategoriDto(restanser.merverdiavgift);
+        Arbeidsgiveravgift = restanser.arbeidsgiveravgift != null ? new RestanserKategoriDto(restanser.arbeidsgiveravgift) : null;
+        Forskuddstrekk = restanser.forskuddstrekk != null ? new RestanserKategoriDto(restanser.forskuddstrekk) : null;
+        Forskuddsskatt = restanser.forskuddsskatt != null ? new RestanserKategoriDto(restanser.forskuddsskatt) : null;
+        Restskatt = restanser.restskatt != null ? new RestanserKategoriDto(restanser.restskatt) : null;
+        Gebyr = restanser.gebyr != null ? new RestanserKategoriDto(restanser.gebyr) : null;
+        Merverdiavgift = restanser.merverdiavgift != null ? new RestanserKategoriDto(restanser.merverdiavgift) : null;
     }
 
     [JsonProperty("arbeidsgiveravgift")]

--- a/src/Dan.Plugin.Skatteetaten/Models/OppdragUtenlandskeVirksomheterModel.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/OppdragUtenlandskeVirksomheterModel.cs
@@ -1,0 +1,15 @@
+namespace Dan.Plugin.Skatteetaten.Models.OppdragUtenlandskeVirksomheter
+{
+    public class OppdragAntall
+    {
+        public int antallAktiveOppdragSomArbeidsgiver { get; set; }
+        public int antallAktiveArbeidstakere { get; set; }
+        public int antallRegistrerteOppdragSomOppdragsgiver { get; set; }
+    }
+
+    public class OppdragUtenlandskeVirksomheterModel
+    {
+        public string forespurteOrganisasjon { get; set; }
+        public OppdragAntall oppdrag { get; set; }
+    }
+}

--- a/src/Dan.Plugin.Skatteetaten/Models/PayrollTaxModel.cs
+++ b/src/Dan.Plugin.Skatteetaten/Models/PayrollTaxModel.cs
@@ -1,22 +1,24 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Dan.Plugin.Skatteetaten.Models.Arbeidsgiveravgift
 {
-    public class Arbeidsgiveravgift
+    public class ArbeidsgiveravgiftEntry
     {
         public string termin { get; set; }
         public string aar { get; set; }
-        public int sumavgiftsgrunnlagBeloep { get; set; }
+        public long sumavgiftsgrunnlagBeloep { get; set; }
+    }
+
+    public class ArbeidsgiveravgiftWrapper
+    {
+        public ArbeidsgiveravgiftEntry arbeidsgiveravgift { get; set; }
     }
 
     public class PayrollTaxModel
     {
         public DateTime levert { get; set; }
         public string forespurteOrganisasjon { get; set; }
-        public List<Arbeidsgiveravgift> arbeidsgiveravgifter { get; set; }
+        public List<ArbeidsgiveravgiftWrapper> arbeidsgiveravgifter { get; set; }
     }
-
-
 }

--- a/src/Dan.Plugin.Skatteetaten/OppdragUtenlandskeVirksomheter.cs
+++ b/src/Dan.Plugin.Skatteetaten/OppdragUtenlandskeVirksomheter.cs
@@ -2,15 +2,16 @@ using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Dan.Common.Util;
 using Dan.Plugin.Skatteetaten.Config;
+using Dan.Plugin.Skatteetaten.Models;
+using Dan.Plugin.Skatteetaten.Models.Dtos;
+using Dan.Plugin.Skatteetaten.Models.OppdragUtenlandskeVirksomheter;
 using Dan.Plugin.Skatteetaten.Utilities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using DanConstants = Dan.Common.Constants;
@@ -33,90 +34,24 @@ namespace Dan.Plugin.Skatteetaten
             _evidenceSourceMetadata = metadata;
         }
 
-
         [Function("OppdragUtenlandskeVirksomheter")]
         public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req, FunctionContext context)
         {
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            var evidenceHarvesterRequest = JsonConvert.DeserializeObject<EvidenceHarvesterRequest>(requestBody);
-
-            return await EvidenceSourceResponse.CreateResponse(req, ()=> GetFromSkeAsync(evidenceHarvesterRequest));
+            var evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
+            return await EvidenceSourceResponse.CreateResponse(req, () => GetFromSkeAsync(evidenceHarvesterRequest));
         }
-
 
         private async Task<List<EvidenceValue>> GetFromSkeAsync(EvidenceHarvesterRequest req)
         {
             // yes, the 'utenlandskevirksomheter' path needs to be there despite the baseurl already defining it
             // https://app.swaggerhub.com/apis/skatteetaten/oppdrag-utenlandske-virksomheter-api/1.1.0
             var url = $"{_settings.OppdragUtenlandskeVirksomheterEndpoint}/v1/ebevis/utenlandskevirksomheter/{req.OrganizationNumber}/oppdrag/antall";
-            dynamic result = await Helpers.HarvestFromSke(req, _logger, _client, HttpMethod.Get, url, _settings);
+            var result = await Helpers.HarvestFromSke<OppdragUtenlandskeVirksomheterModel>(req, _logger, _client, HttpMethod.Get, url, _settings);
 
-            string orgNo = string.Empty;
-            int activeJobs = 0;
-            int activeEmployees = 0;
-            int registeredJobsAsEmployer = 0;
-
-            // string orgName = result["..."};
+            var dto = new OppdragUtenlandskeVirksomheterDto(result);
 
             var ecb = new EvidenceBuilder(_evidenceSourceMetadata, "OppdragUtenlandskeVirksomheter");
-
-            try
-            {
-                if (result["forespurteOrganisasjon"] != null)
-                {
-                    orgNo = result["forespurteOrganisasjon"];
-                    ecb.AddEvidenceValue("organisasjonsnummer", orgNo);
-                }
-            }
-            catch(Exception ex)
-            {
-                _logger.LogError("Could not parse org. no. value : " + orgNo + ". Exception: " + ex.ToString());
-            }
-
-            if (result["oppdrag"] != null)
-            {
-                if (result["oppdrag"]["antallAktiveOppdragSomArbeidsgiver"] != null)
-                {
-                    try
-                    {
-                        activeJobs = int.Parse(Convert.ToString(result["oppdrag"]["antallAktiveOppdragSomArbeidsgiver"]));
-                        ecb.AddEvidenceValue("antallAktiveOppdragSomArbeidsgiver", activeJobs);
-                    }
-                    catch(Exception ex)
-                    {
-                        _logger.LogError("Could not parse activeJobs value : " + activeJobs + ". Exception: " + ex.ToString());
-                    }
-
-                }
-
-                if (result["oppdrag"]["antallAktiveArbeidstakere"] != null)
-                {
-                    try
-                    {
-                        activeEmployees = int.Parse(Convert.ToString(result["oppdrag"]["antallAktiveArbeidstakere"]));
-                        ecb.AddEvidenceValue("antallAktiveArbeidstakere", activeEmployees);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError("Could not parse antallAktiveArbeidstakere value : " + activeEmployees + ". Exception: " + ex.ToString());
-                    }
-                }
-
-
-                if (result["oppdrag"]["antallRegistrerteOppdragSomOppdragsgiver"] != null)
-                {
-                    try
-                    {
-                        registeredJobsAsEmployer = int.Parse(Convert.ToString(result["oppdrag"]["antallRegistrerteOppdragSomOppdragsgiver"]));
-                        ecb.AddEvidenceValue("antallRegistrerteOppdragSomOppdragsgiver", registeredJobsAsEmployer);
-                    }
-                    catch(Exception ex)
-                    {
-                        _logger.LogError("Could not parse antallRegistrerteOppdragSomOppdragsgiver value : " + registeredJobsAsEmployer + ". Exception: " + ex.ToString());
-                    }
-                }
-            }
-
+            ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(dto), Constants.Source, false);
             return ecb.GetEvidenceValues();
         }
     }

--- a/src/Dan.Plugin.Skatteetaten/PayrollTax.cs
+++ b/src/Dan.Plugin.Skatteetaten/PayrollTax.cs
@@ -1,25 +1,23 @@
-using Dan.Common.Exceptions;
 using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Dan.Common.Util;
 using Dan.Plugin.Skatteetaten.Config;
-using Dan.Plugin.Skatteetaten.Models.Arbeidsgiveravgift;
-using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Options;
 using Dan.Plugin.Skatteetaten.Models;
+using Dan.Plugin.Skatteetaten.Models.Arbeidsgiveravgift;
+using Dan.Plugin.Skatteetaten.Models.Dtos;
+using Dan.Plugin.Skatteetaten.Utilities;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Dan.Plugin.Skatteetaten.Utilities;
-using Microsoft.Azure.Functions.Worker.Http;
 using DanConstants = Dan.Common.Constants;
+
 namespace Dan.Plugin.Skatteetaten
 {
-
     public class PayrollTax
     {
         private HttpClient _client;
@@ -41,43 +39,18 @@ namespace Dan.Plugin.Skatteetaten
             FunctionContext context)
         {
             var evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
-
-            return await EvidenceSourceResponse.CreateResponse(req, ()=> GetPayrollTaxFromSkeAsync(evidenceHarvesterRequest, _logger));
+            return await EvidenceSourceResponse.CreateResponse(req, () => GetPayrollTaxFromSkeAsync(evidenceHarvesterRequest));
         }
 
-        private async Task<List<EvidenceValue>> GetPayrollTaxFromSkeAsync(EvidenceHarvesterRequest evidenceHarvesterRequest, ILogger logger)
+        private async Task<List<EvidenceValue>> GetPayrollTaxFromSkeAsync(EvidenceHarvesterRequest evidenceHarvesterRequest)
         {
             var url = $"{_settings.ArbeidsgiveravgiftEndpoint}/v1/ebevis/{evidenceHarvesterRequest.OrganizationNumber}";
-            var result = await Helpers.HarvestFromSke(evidenceHarvesterRequest, logger, _client, HttpMethod.Get, url, _settings);
+            var result = await Helpers.HarvestFromSke<PayrollTaxModel>(evidenceHarvesterRequest, _logger, _client, HttpMethod.Get, url, _settings);
+
+            var dto = new ArbeidsgiveravgiftDto(result);
 
             var ecb = new EvidenceBuilder(_metadata, "Arbeidsgiveravgift");
-            try
-            {
-                ecb.AddEvidenceValue($"levert", result.levert);
-            }
-            catch(Exception ex)
-            {
-                logger.LogError("Error parsing 'levert' : " + ex.ToString());
-            }
-
-            try
-            {
-                ecb.AddEvidenceValue($"forespurteOrganisasjon", result.forespurteOrganisasjon);
-            }
-            catch(Exception ex)
-            {
-                logger.LogError("Error parsing 'forespurteOrganisasjon' : " + ex.ToString());
-            }
-
-            try
-            {
-                ecb.AddEvidenceValue($"arbeidsgiveravgifter", JsonConvert.SerializeObject(result.arbeidsgiveravgifter), Constants.Source, false);
-            }
-            catch(Exception ex)
-            {
-                logger.LogError("Error parsing 'arbeidsgiveravgifter' : " + ex.ToString());
-            }
-
+            ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(dto), Constants.Source, false);
             return ecb.GetEvidenceValues();
         }
     }

--- a/src/Dan.Plugin.Skatteetaten/VATReport.cs
+++ b/src/Dan.Plugin.Skatteetaten/VATReport.cs
@@ -1,16 +1,15 @@
-using Dan.Common.Exceptions;
 using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Dan.Common.Util;
 using Dan.Plugin.Skatteetaten.Config;
 using Dan.Plugin.Skatteetaten.Models;
+using Dan.Plugin.Skatteetaten.Models.Dtos;
 using Dan.Plugin.Skatteetaten.Utilities;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -37,8 +36,7 @@ namespace Dan.Plugin.Skatteetaten
         public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req, FunctionContext context)
         {
             var evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
-
-            return await EvidenceSourceResponse.CreateResponse(req, ()=> GetFromSKE(evidenceHarvesterRequest));
+            return await EvidenceSourceResponse.CreateResponse(req, () => GetFromSKE(evidenceHarvesterRequest));
         }
 
         private async Task<List<EvidenceValue>> GetFromSKE(EvidenceHarvesterRequest evidenceHarvesterRequest)
@@ -46,18 +44,10 @@ namespace Dan.Plugin.Skatteetaten
             var url = $"{_settings.MvaMeldingsOpplysningEndpoint}/v1/ebevis/{evidenceHarvesterRequest.OrganizationNumber}";
             var result = await Helpers.HarvestFromSke<VATReportModel>(evidenceHarvesterRequest, _logger, _client, HttpMethod.Get, url);
 
-            DateTime delivered = result.levert;
-            string orgNo = result.forespurteOrganisasjon;
-            string VATregularBusiness = JsonConvert.SerializeObject(result.mvaAlminneligNaering);
-            // string responsibleOrgForVatReport = JsonConvert.SerializeObject(result.ansvarligForMvaMelding);
+            var dto = new MvaMeldingsOpplysningDto(result);
 
             var ecb = new EvidenceBuilder(_metadata, "MvaMeldingsOpplysning");
-
-            ecb.AddEvidenceValue($"levert", delivered);
-            ecb.AddEvidenceValue($"forespurteOrganisasjon", orgNo);
-            ecb.AddEvidenceValue($"mvaAlminneligNaering", VATregularBusiness);
-            // ecb.AddEvidenceValue($"ansvarligForMvaMelding", responsibleOrgForVatReport);
-
+            ecb.AddEvidenceValue("default", JsonConvert.SerializeObject(dto), Constants.Source, false);
             return ecb.GetEvidenceValues();
         }
     }

--- a/test/Dan.Plugin.Skatteetaten.Test/FregPersonDtoTests.cs
+++ b/test/Dan.Plugin.Skatteetaten.Test/FregPersonDtoTests.cs
@@ -1,0 +1,265 @@
+using AwesomeAssertions;
+using Dan.Plugin.Skatteetaten.Models.Dtos;
+using Grpc.Core;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Dan.Plugin.Skatteetaten.Test;
+
+public class FregPersonDtoTests
+{
+    // Mirrors the settings used in Freg.cs
+    private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    //FregPerson endpoint should contain, ident, status, kjonn, fodsel, sivilstand, navn, bostedsadresse, statsborgerskap and status
+    private const string SampleFregPersonJson = """
+        {
+            "identifikasjonsnummer": [
+                {
+                    "ajourholdstidspunkt": "2020-12-22T16:09:53.4+00:00",
+                    "erGjeldende": true,
+                    "kilde": "KILDE_DSF",
+                    "status": "iBruk",
+                    "foedselsEllerDNummer": "29816595620",
+                    "identifikatortype": "foedselsnummer"
+                }
+            ],
+            "status":[
+                    {
+                        "ajourholdstidspunkt": "2020-12-22T16:09:53.4+00:00",
+                        "erGjeldende": true,
+                        "kilde": "KILDE_DSF",
+                        "gyldighetstidspunkt": "2020-12-22T16:09:53.4+00:00",
+                        "status": "bosatt"   
+                    }
+                ],
+            "kjoenn": [
+                {
+                    "erGjeldende": true,
+                    "kilde": "KILDE_DSF",
+                    "kjoenn": "kvinne"
+                }
+            ],
+            "foedsel": [
+                    {
+                        "ajourholdstidspunkt": "2022-03-11T08:25:20.86733+00:00",
+                        "erGjeldende": true,
+                        "kilde": "Synutopia",
+                        "gyldighetstidspunkt": "1965-01-29T08:25:20.867293+00:00",
+                        "foedselsdato": "1965-01-29",
+                        "foedselsaar": "1965",
+                        "foedekommuneINorge": "5401",
+                        "foedeland": "NOR"
+                    }
+                ],
+            "sivilstand": [
+                    {
+                        "ajourholdstidspunkt": "2022-03-11T08:25:20.999907+00:00",
+                        "erGjeldende": true,
+                        "kilde": "Synutopia",
+                        "aarsak": "Fødsel",
+                        "gyldighetstidspunkt": "1965-01-29T08:25:20.999926+00:00",
+                        "sivilstand": "ugift",
+                        "sivilstandsdato": "1965-01-29"
+                    }
+                ],
+            "navn": [
+                {
+                    "ajourholdstidspunkt": "2022-03-11T08:25:20.957496+00:00",
+                    "erGjeldende": true,
+                    "kilde": "Synutopia",
+                    "fornavn": "ALMINNELIG",
+                    "etternavn": "AGENT"
+                }
+            ],
+            "bostedsadresse": [
+                {
+                    "erGjeldende": true,
+                    "kilde": "Matrikkelen",
+                    "vegadresse": {
+                        "kommunenummer": "5001",
+                        "adressenavn": "Blaklihøgda",
+                        "adressenummer": { "husnummer": "1", "husbokstav": "A" },
+                        "poststed": { "postnummer": "7036", "poststedsnavn": "TRONDHEIM" }
+                    }
+                }                
+            ],
+            "statsborgerskap": [
+                {
+                    "aarsak":  "FÃ¸dsel",
+                    "ajourholdstidspunkt":  "2022-03-11T09:25:21.045163+01:00",
+                    "erGjeldende":  true,
+                    "ervervsdato":  "1965-01-29",
+                    "gyldighetstidspunkt":  "1965-01-29T09:25:21.045197+01:00",
+                    "kilde":  "Synutopia",
+                    "statsborgerskap":  "NOR"
+                }
+            ],
+            "status": [
+                {
+                    "ajourholdstidspunkt":  "2020-12-22T17:09:53.4+01:00",
+                    "erGjeldende":  true,
+                    "gyldighetstidspunkt":  "2020-12-22T17:09:53.4+01:00",
+                    "kilde":  "KILDE_DSF",
+                    "status":  "bosatt"
+                }
+            ]
+        }
+        """;
+
+    //FregPersonRealasjonUtvidet endpoint should contain ident and familierelasjon
+    private const string SampleFregPersonRelasjonUtvidetJson = """
+        {
+            "familierelasjon": [
+                {
+                    "erGjeldende": true,
+                    "kilde": "Synutopia",
+                    "minRolleForPerson": "mor",
+                    "relatertPerson": "12345678901",
+                    "relatertPersonsRolle": "barn"
+                }
+            ],
+            "identifikasjonsnummer": [
+            {
+                "ajourholdstidspunkt": "2020-12-22T16:09:53.4+00:00",
+                "erGjeldende": true,
+                "kilde": "KILDE_DSF",
+                "status": "iBruk",
+                "foedselsEllerDNummer": "29816595620",
+                "identifikatortype": "foedselsnummer"
+            }
+        ]   
+        }
+        """;
+
+    // FregPersonUtenHjemmel endpoint should contain, ident, status, kjonn, fodsel, sivilstand, navn, bostedsadresse, statsborgerskap
+    private const string SampleFregPersonUtenHjemmelJson = """
+        {
+            "identifikasjonsnummer": [
+                {
+                    "ajourholdstidspunkt": "2020-12-22T16:09:53.4+00:00",
+                    "erGjeldende": true,
+                    "kilde": "KILDE_DSF",
+                    "status": "iBruk",
+                    "foedselsEllerDNummer": "29816595620",
+                    "identifikatortype": "foedselsnummer"
+                }
+            ],
+            "status": [
+                {
+                    "ajourholdstidspunkt": "2020-12-22T16:09:53.4+00:00",
+                    "erGjeldende": true,
+                    "gyldighetstidspunkt": "2020-12-22T16:09:53.4+00:00",
+                    "status": "bosatt"
+                }
+            ],
+            "kjoenn": [
+                {
+                    "erGjeldende": true,
+                    "kilde": "KILDE_DSF",
+                    "kjoenn": "kvinne"
+                }
+            ],
+            "foedsel": [
+                {
+                    "ajourholdstidspunkt": "2022-03-11T08:25:20.86733+00:00",
+                    "erGjeldende": true,
+                    "gyldighetstidspunkt": "1965-01-29T08:25:20.867293+00:00",
+                    "foedselsdato": "1965-01-29",
+                    "foedselsaar": "1965",
+                    "foedekommuneINorge": "5401",
+                    "foedeland": "NOR"
+                }
+            ],
+            "sivilstand": [
+                {
+                    "erGjeldende": true,
+                    "sivilstand": "ugift"
+                }
+            ],
+            "navn": [
+                {
+                    "ajourholdstidspunkt": "2022-03-11T08:25:20.957496+00:00",
+                    "erGjeldende": true,
+                    "kilde": "Synutopia",
+                    "fornavn": "ALMINNELIG",
+                    "etternavn": "AGENT"
+                }
+            ],
+            "bostedsadresse": [
+                {
+                    "erGjeldende": true,
+                    "kilde": "Matrikkelen",
+                    "vegadresse": {
+                        "kommunenummer": "5001",
+                        "adressenavn": "Blaklihøgda",
+                        "adressenummer": { "husnummer": "1", "husbokstav": "A" },
+                        "poststed": { "postnummer": "7036", "poststedsnavn": "TRONDHEIM" }
+                    }
+                }
+            ],
+            "statsborgerskap": [
+                {
+                    "erGjeldende": true,
+                    "statsborgerskap": "NOR"
+                }
+            ]
+        }
+        """;
+
+    [Fact]
+    public void FregPerson_serialization_contains_correct_fields()
+    {
+        var dto = JsonConvert.DeserializeObject<FregPersonDto>(SampleFregPersonJson);
+        var json = JObject.Parse(JsonConvert.SerializeObject(dto, JsonSettings));
+
+        // Populated parts are present
+        json.Should().ContainKey("identifikasjonsnummer");
+        json.Should().ContainKey("kjoenn");
+        json.Should().ContainKey("navn");
+        json.Should().ContainKey("bostedsadresse");
+        json.Should().ContainKey("foedsel");
+        json.Should().ContainKey("sivilstand");
+        json.Should().ContainKey("statsborgerskap");
+        json.Should().ContainKey("status");
+    }
+
+    [Fact]
+    public void FregPersonRelasjonUtvidet_contains_correct_fields()
+    {
+        var dto = JsonConvert.DeserializeObject<FregPersonDto>(SampleFregPersonRelasjonUtvidetJson);
+        var json = JObject.Parse(JsonConvert.SerializeObject(dto, JsonSettings));
+
+        // Populated parts are present
+        json.Should().ContainKey("familierelasjon");
+        json.Should().ContainKey("identifikasjonsnummer");
+        json.Should().NotContainKey("status");
+        json.Should().NotContainKey("kjoenn");
+        json.Should().NotContainKey("foedsel");
+        json.Should().NotContainKey("sivilstand");
+        json.Should().NotContainKey("navn");
+        json.Should().NotContainKey("bostedsadresse");
+        json.Should().NotContainKey("statsborgerskap");
+    }
+
+    [Fact]
+    public void FregPersonUtenHjemmel_contains_correct_fields()
+    {
+        // FregPersonUtenHjemmel and FregPerson contains the same properties
+        var dto = JsonConvert.DeserializeObject<FregPersonDto>(SampleFregPersonUtenHjemmelJson);
+        var json = JObject.Parse(JsonConvert.SerializeObject(dto, JsonSettings));
+
+        json.Should().ContainKey("identifikasjonsnummer");       
+        json.Should().ContainKey("status");       
+        json.Should().ContainKey("kjoenn");       
+        json.Should().ContainKey("foedsel");       
+        json.Should().ContainKey("sivilstand");       
+        json.Should().ContainKey("navn");       
+        json.Should().ContainKey("bostedsadresse");       
+        json.Should().ContainKey("statsborgerskap");       
+    }
+}

--- a/test/Dan.Plugin.Skatteetaten.Test/FregPersonDtoTests.cs
+++ b/test/Dan.Plugin.Skatteetaten.Test/FregPersonDtoTests.cs
@@ -98,15 +98,6 @@ public class FregPersonDtoTests
                     "kilde":  "Synutopia",
                     "statsborgerskap":  "NOR"
                 }
-            ],
-            "status": [
-                {
-                    "ajourholdstidspunkt":  "2020-12-22T17:09:53.4+01:00",
-                    "erGjeldende":  true,
-                    "gyldighetstidspunkt":  "2020-12-22T17:09:53.4+01:00",
-                    "kilde":  "KILDE_DSF",
-                    "status":  "bosatt"
-                }
             ]
         }
         """;


### PR DESCRIPTION
### Description
<!--- What and why -->
Added DTOs to endpoints. 
Freg endpoints use the same DTO and cotains all properties of the endpoints but will ignore all properties where the value is null.
This ensures that the model will look identical to what it did before the DTOs.
### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evidence responses now return a single structured JSON payload under the `default` evidence entry for tax debt, payroll tax, VAT, foreign assignments, and population registry data.
  * Introduced typed DTOs and an updated REST output structure for totals and categories.
  * Evidence metadata schemas are now generated from the DTOs for a consistent response shape.
* **Bug Fixes**
  * Improved reliability and consistency by switching to strongly typed harvesting and serialization that omits nulls for registry evidence.
* **Tests**
  * Added coverage verifying `FregPersonDto` JSON serialization field presence/absence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->